### PR TITLE
allow users to push the tag image to another custom tag

### DIFF
--- a/docs/.aicoe-ci.yaml
+++ b/docs/.aicoe-ci.yaml
@@ -10,6 +10,7 @@ build:
   base-image: registry.access.redhat.com/ubi8/ubi:latest
   build-stratergy: Dockerfile # Allowed values: Source, Dockerfile, Containerfile (default: Source)
   dockerfile-path: Dockerfile
+  custom_tag: latest # custom tag to be push to registry
   registry: quay.io # Imgage registry to be used. (default: quay.io)
   registry-org: thoth-station # Organization to be used in Image Registry. (default: thoth-station)
   registry-project: example # Project Repository in Image Registry to be used to push image.

--- a/pipeline/tag-release-pipeline.yaml
+++ b/pipeline/tag-release-pipeline.yaml
@@ -115,6 +115,8 @@ spec:
           value: $(tasks.configuration.results.dockerfile-path)
         - name: build_source_script
           value: $(tasks.configuration.results.build-source-script)
+        - name: custom_tag
+          value: $(tasks.configuration.results.custom-tag)
         - name: registry
           value: $(tasks.configuration.results.registry)
         - name: registry_org

--- a/tasks/configuration-task.yaml
+++ b/tasks/configuration-task.yaml
@@ -14,6 +14,7 @@ spec:
     - name: build-stratergy
     - name: dockerfile-path
     - name: build-source-script
+    - name: custom-tag
     - name: registry
     - name: registry-org
     - name: registry-project
@@ -45,6 +46,7 @@ spec:
             build-stratergy: ""
             dockerfile-path: ""
             build-source-script: ""
+            custom-tag: ""
             registry: "quay.io"
             registry-org: "thoth-station"
             registry-project: ""
@@ -61,6 +63,7 @@ spec:
         echo -n $(yq r .aicoe-ci.yaml build.registry-org) > $(results.registry-org.path)
         echo -n $(yq r .aicoe-ci.yaml build.build-stratergy) > $(results.build-stratergy.path)
         echo -n $(yq r .aicoe-ci.yaml build.dockerfile-path) > $(results.dockerfile-path.path)
+        echo -n $(yq r .aicoe-ci.yaml build.custom-tag) > $(results.custom-tag.path)
         echo -n $(yq r .aicoe-ci.yaml build.build-source-script) > $(results.build-source-script.path)
         echo -n $(yq r .aicoe-ci.yaml build.registry-project) > $(results.registry-project.path)
         echo -n $(yq r -j .aicoe-ci.yaml pytest-env) > $(results.pytest-env.path)

--- a/tasks/tag-release-task.yaml
+++ b/tasks/tag-release-task.yaml
@@ -21,6 +21,9 @@ spec:
     - name: build_source_script
       description: Specify a URL for the assemble, assemble-runtime and run scripts
       default: ""
+    - name: custom_tag
+      description: additional custom tag to be pushed along.
+      default: ""
     - name: registry
       description: Container image registry.
       default: "quay.io"
@@ -227,6 +230,30 @@ spec:
         --tls-verify=$(params.TLSVERIFY) \
         $(params.repo_name)-$(params.git_ref) \
         docker://$(params.registry)/$(params.registry_org)/$registry_repo:$(params.git_ref)
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - name: varlibcontainers
+          mountPath: /var/lib/containers
+        - name: quay-creds
+          mountPath: /pushsecret/
+          readOnly: true
+
+    - name: push-custom-tag
+      image: quay.io/buildah/stable
+      script: |
+        if [ -z "$(params.registry_project)" ]; then
+          registry_repo=$(params.repo_name)
+        else
+          registry_repo=$(params.registry_project)
+        fi
+        if [ ! -z "$(params.custom_tag)" ]; then
+          buildah push \
+          --authfile=/pushsecret/.dockerconfigjson \
+          --tls-verify=$(params.TLSVERIFY) \
+          $(params.repo_name)-$(params.git_ref) \
+          docker://$(params.registry)/$(params.registry_org)/$registry_repo:$(params.custom_tag)
+        fi
       securityContext:
         privileged: true
       volumeMounts:


### PR DESCRIPTION
## Related Issues and Dependencies

Related-to: #68 #47 

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

use the configuration variable and push to the custom tag

## Description

allow users to push the tag image to another custom tag
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>