### PR TITLE
add Architectural Decision Record

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,53 @@ AICoE-CI is a continuous integration and delivery system based on Tekton-Pipelin
 AICoE-CI is developed with Tekton Pipeline concepts.Pipeline are triggered with Tekton Triggers which functions based on git webhook events.<br>
 On the webhook triggered events, different pipeline are triggered to provide different services based on Pull Request, Issues and Tag releases.
 
-# Getting Started
+## Architecture
 
-## Setting AICoE-CI on GitHub Organization/Repository
+![aicoe-ci architecture](/docs/arch.png)
+
+### Services and Features
+
+- Status Check on Pull request for testing and containerization.
+
+  - `aicoe-ci/pre-commit-check` execute [pre-commit](https://pre-commit.com/) checks based on [pre-commit-config.yaml](.pre-commit-config.yaml).
+  - `aicoe-ci/pytest-check` executes run python test.
+  - `aicoe-ci/coala-check` executes [coala](https://coala.io/#/home) linting checks based on [.coafile]() (**Deprecated**)
+  - `aicoe-ci/build-check` execute container image build check.<br>
+    Supports source-to-image, Dockerfile, Containerfile based image. (Default `source-to-image`, if Dockerfile or Containerfile are not present)
+
+- Building Container image on Tag release and for Pull request.
+
+  - On Tag release, the pipeline would build the image based upon the tag and release to [quay.io](https://quay.io/).
+  - Pull request based image can be build by commenting `/deploy` on the pull-request comment to release the image to [quay.io](https://quay.io/).
+
+#### GitHub ChatOps Options:
+
+AICoE-CI provides some GitHub comment commands for pull request processing on GitHub.<br>
+Developers can comment following commands on Github pull request.
+
+- `/retest`
+- `/deploy`
+
+All the Pull Request status checks can be rerun by the following command.<br>
+command: `/retest`
+
+In a Development environment, if the application is setup with image registry in the aicoe-ci configuration file. Then with the following command, aicoe-ci can assist with building an image out of the pull request and pushing the image to configured image registry.<br>
+command: `/deploy`
+
+### Architectural decisions
+
+We keep track of architectural decisions using lightweight architectural decision records. More information on the
+used format is available at https://adr.github.io/madr/. General information about architectural decision records
+is available at https://adr.github.io/ .
+
+Architectural decisions
+
+* [ADR-0000](docs/adr/0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
+* [ADR-0001](docs/adr/0001-use-gpl3-as-license.md) - Use GNU GPL as license
+
+## Getting Started
+
+### Setting AICoE-CI on GitHub Organization/Repository
 
 Setting up AICoE-CI on to your Github Organization/Repository can be commenced with three simple steps process:
 
@@ -22,12 +66,12 @@ Setting up AICoE-CI on to your Github Organization/Repository can be commenced w
 
 **NOTE**: Interested in Other Thoth-bots, AICoE-CI works very well with other bots. More information on Setup of other Thoth Bots: [Thoth Bots Setup](docs/thoth-bots-setup.md)
 
-## AICoE-CI configuration file
+### AICoE-CI configuration file
 
 The AICoE-CI configuration file is to be added to the root of the repository directory and to be named: `.aicoe-ci.yaml`<br>
 It allows the user to configure checks, release modules to pypi, build preferences and update imagestream in kustomize yaml file.
 
-### Configuring checks and tests
+#### Configuring checks and tests
 
 CI provides following checks for pull requests.Each check is independent of each other, so users can pick and choose the tests which they require for there repository. It can be added into the `.aicoe.yaml` configuration file, as shown in the example snippet below.
 
@@ -52,7 +96,7 @@ More information on available checks/tests:
 
 If users require more custom checks/tests, please open a feature request issue with detailed explanation of the tests requirement.
 
-### Configuring Build requirements
+#### Configuring Build requirements
 
 Configuration files allows user assign details about the build requirements and specify base image and registry details for build and push.
 
@@ -76,40 +120,7 @@ Thoth-Station     | thoth-station-thoth-pusher-secret
 OpenDataHub       | opendatahub-thoth-pusher-secret
 ODH-Jupyterhub    | odh-jupyterhub-thoth-pusher-secret
 
-## Architecture
-
-![aicoe-ci architecture](/docs/arch.png)
-
-## Services and Features
-
-- Status Check on Pull request for testing and containerization.
-
-  - `aicoe-ci/pre-commit-check` execute [pre-commit](https://pre-commit.com/) checks based on [pre-commit-config.yaml](.pre-commit-config.yaml).
-  - `aicoe-ci/pytest-check` executes run python test.
-  - `aicoe-ci/coala-check` executes [coala](https://coala.io/#/home) linting checks based on [.coafile]() (**Deprecated**)
-  - `aicoe-ci/build-check` execute container image build check.<br>
-    Supports source-to-image, Dockerfile, Containerfile based image. (Default `source-to-image`, if Dockerfile or Containerfile are not present)
-
-- Building Container image on Tag release and for Pull request.
-
-  - On Tag release, the pipeline would build the image based upon the tag and release to [quay.io](https://quay.io/).
-  - Pull request based image can be build by commenting `/deploy` on the pull-request comment to release the image to [quay.io](https://quay.io/).
-
-### GitHub ChatOps Options:
-
-AICoE-CI provides some GitHub comment commands for pull request processing on GitHub.<br>
-Developers can comment following commands on Github pull request.
-
-- `/retest`
-- `/deploy`
-
-All the Pull Request status checks can be rerun by the following command.<br>
-command: `/retest`
-
-In a Development environment, if the application is setup with image registry in the aicoe-ci configuration file. Then with the following command, aicoe-ci can assist with building an image out of the pull request and pushing the image to configured image registry.<br>
-command: `/deploy`
-
-# How to Contribute
+## How to Contribute
 
 - For Overview on AICoE-CI Pipeline, check: [AICoE-CI Development]()
 - For Contribution Details and Setup of dev environment: [Setup and Contribution](docs/how-to-contribute.md)

--- a/docs/adr/0000-use-markdown-architectural-decision-records.md
+++ b/docs/adr/0000-use-markdown-architectural-decision-records.md
@@ -1,0 +1,28 @@
+# Use Markdown Architectural Decision Records
+
+## Context and Problem Statement
+
+We want to record architectural decisions made in Project Thoth. Which format and structure should these records follow?
+
+## Considered Options
+
+* [MADR](https://adr.github.io/madr/) 2.1.2 – The Markdown Architectural Decision Records
+* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) – The first incarnation of the term "ADR"
+* [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) – The Y-Statements
+* Other templates listed at [https://github.com/joelparkerhenderson/architecture\_decision\_record](https://github.com/joelparkerhenderson/architecture_decision_record)
+* Formless – No conventions for file format and structure
+
+## Decision Outcome
+
+Chosen option: "MADR 2.1.2", because
+
+* Implicit assumptions should be made explicit.
+
+  Design documentation is important to enable people understanding the decisions later on.
+
+  See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
+
+* The MADR format is lean and fits our development style.
+* The MADR structure is comprehensible and facilitates usage & maintenance.
+* The MADR project is vivid.
+* Version 2.1.2 is the latest one available when starting to document ADRs.

--- a/docs/adr/0001-use-gpl3-as-license.md
+++ b/docs/adr/0001-use-gpl3-as-license.md
@@ -1,0 +1,18 @@
+# Use GNU GPL as license
+
+Everything needs to be licensed, otherwise the default copyright laws apply.
+For instance, in Germany that means users may not alter anything without explicitly asking for permission.
+For more information see <https://help.github.com/articles/licensing-a-repository/>.
+
+We want to have all source code related to Project Thoth to be used without any hassle and as free as possible, so that
+users can just [execute and enjoy the four freedoms](https://fsfe.org/freesoftware/freesoftware.en.html).
+
+## Considered Options
+
+* No license
+* [CC0](https://creativecommons.org/share-your-work/public-domain/cc0/)
+* [GNU GPL](http://www.gnu.org/licenses/gpl-3.0.en.html)
+
+## Decision Outcome
+
+Chosen option: "GNU GPL", because this license supports a strong copyleft model.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,74 @@
+# [short title of solved problem and solution]
+
+* Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- optional -->
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->
+
+<!-- markdownlint-disable-file MD013 -->


### PR DESCRIPTION
add ADR documentation to keep track of architectural decisions

Signed-off-by: Christoph Görn <goern@redhat.com>

## This introduces a breaking change

- [ ] Yes
- [x] No
