### PR TITLE
enable GIT_REPO_NAME to be added to the s2i image builds

### DIFF
--- a/tasks/issue-release-task.yaml
+++ b/tasks/issue-release-task.yaml
@@ -189,6 +189,7 @@ spec:
               --env THAMOS_DEBUG=$(params.THAMOS_DEBUG) \
               --env THAMOS_VERBOSE=$(params.THAMOS_VERBOSE) \
               --env THOTH_PROVENANCE_CHECK=$(params.THOTH_PROVENANCE_CHECK) \
+              --env GIT_REPO_NAME=$(params.repo_name)  \
               --loglevel=$(params.LOGLEVEL) \
               --as-dockerfile /gen-source/Containerfile
             else

--- a/tasks/pr-build-release.yaml
+++ b/tasks/pr-build-release.yaml
@@ -172,6 +172,7 @@ spec:
               --env THAMOS_DEBUG=$(params.THAMOS_DEBUG) \
               --env THAMOS_VERBOSE=$(params.THAMOS_VERBOSE) \
               --env THOTH_PROVENANCE_CHECK=$(params.THOTH_PROVENANCE_CHECK) \
+              --env GIT_REPO_NAME=$(params.pr_repo)  \
               --loglevel=$(params.LOGLEVEL) \
               --as-dockerfile /gen-source/Containerfile
             else

--- a/tasks/pr-build.yaml
+++ b/tasks/pr-build.yaml
@@ -137,6 +137,7 @@ spec:
               --env THAMOS_DEBUG=$(params.THAMOS_DEBUG) \
               --env THAMOS_VERBOSE=$(params.THAMOS_VERBOSE) \
               --env THOTH_PROVENANCE_CHECK=$(params.THOTH_PROVENANCE_CHECK) \
+              --env GIT_REPO_NAME=$(params.pr_repo) \
               --loglevel=$(params.LOGLEVEL) \
               --as-dockerfile /gen-source/Containerfile
             else

--- a/tasks/tag-release-task.yaml
+++ b/tasks/tag-release-task.yaml
@@ -171,6 +171,7 @@ spec:
               --env THAMOS_DEBUG=$(params.THAMOS_DEBUG) \
               --env THAMOS_VERBOSE=$(params.THAMOS_VERBOSE) \
               --env THOTH_PROVENANCE_CHECK=$(params.THOTH_PROVENANCE_CHECK) \
+              --env GIT_REPO_NAME=$(params.repo_name) \
               --loglevel=$(params.LOGLEVEL) \
               --as-dockerfile /gen-source/Containerfile
             else


### PR DESCRIPTION
enable GIT_REPO_NAME to be added to the s2i image builds
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: #82 
