### PR TITLE
fix: Use rbac api group for bindings to sync nicely in ArgoCD

### DIFF
--- a/manifests/overlays/moc/binding.yaml
+++ b/manifests/overlays/moc/binding.yaml
@@ -14,7 +14,7 @@ roleRef:
   name: aicoe-ci-role
 ---
 kind: RoleBinding
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aicoe-ci-webhook-edit
   labels:
@@ -23,10 +23,12 @@ subjects:
   - kind: ServiceAccount
     name: aicoe-ci-webhook
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: edit
 ---
 kind: RoleBinding
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aicoe-ci-edit
   labels:
@@ -35,4 +37,6 @@ subjects:
   - kind: ServiceAccount
     name: aicoe-ci
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: edit

--- a/manifests/overlays/ocp/binding.yaml
+++ b/manifests/overlays/ocp/binding.yaml
@@ -14,7 +14,7 @@ roleRef:
   name: aicoe-ci-role
 ---
 kind: RoleBinding
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aicoe-ci-webhook-edit
   labels:
@@ -23,10 +23,12 @@ subjects:
   - kind: ServiceAccount
     name: aicoe-ci-webhook
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: edit
 ---
 kind: RoleBinding
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aicoe-ci-edit
   labels:
@@ -35,4 +37,6 @@ subjects:
   - kind: ServiceAccount
     name: aicoe-ci
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: edit


### PR DESCRIPTION
Should resolved ArgoCD out of sync on these resources.
![image](https://user-images.githubusercontent.com/7453394/116520648-48ed2900-a8d3-11eb-8623-40f8c78b8d0f.png)

The nature of this problem is rooted in how Openshift handles  `authorization.openshift.io` API. This API is being deprecated/replaced, since it was donated to upstream kubernetes. Hence when a manifest is submitted to `authorization.openshift.io` it gets accepted, but it is internally converted to `rbac.authorization.k8s.io`. That means the sync of the resource into the cluster is successful, but when ArgoCD tries to query for the resource, it no longer exists in this API group, hence it's reported missing by ArgoCD.