### PR TITLE
Fix upstream-sync task

### DIFF
--- a/tasks/repo-upstream-sync.yaml
+++ b/tasks/repo-upstream-sync.yaml
@@ -94,6 +94,8 @@ spec:
         git config --local user.name "$GITHUB_USERNAME"
         upstream_url=$(cat ssh_url.txt)
         git remote add upstream "$upstream_url"
+        NEW_ORIGIN=$(git remote get-url origin | sed 's/https:\/\//git@/g')
+        git remote set-url origin $NEW_ORIGIN
         git remote -v
         git checkout -b aicoe-ci-rebase-update
         export GIT_SSH_COMMAND='ssh -i ~/.ssh/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'


### PR DESCRIPTION
The Upstream-sync task is currently failing at the push command of the
rebase step as it is unable to push via https. This commit will
overwrite the origin url to be ssh-based instead.

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>