### PR TITLE
check the owners file in the repo as well as github association rules

### DIFF
--- a/.github/ISSUE_TEMPLATE/request_sesheta.yaml
+++ b/.github/ISSUE_TEMPLATE/request_sesheta.yaml
@@ -1,5 +1,5 @@
 ---
-name: Help with Sesheta invite 
+name: Help with Sesheta invite
 description: "Create a request to accept invitation for sesheta."
 title: "Help with Sesheta invite"
 labels: [area/cyborgs, bot, sig/cyborgs]
@@ -13,7 +13,7 @@ body:
       attributes:
           label: GitHub Repo
           description: |
-              Provide the github repository url where Sesheta was invite as contributor  
+              Provide the github repository url where Sesheta was invite as contributor
           placeholder: https://github.com/thoth-station/support
       validations:
           required: true

--- a/tasks/init-task.yaml
+++ b/tasks/init-task.yaml
@@ -81,7 +81,13 @@ spec:
         author_association = "$(params.pr_comment_author_association)"
         return_comment = ""
         if "/deploy" == received_comment:
-            if not ((author_association != "OWNER") or (author_association != "MEMBER")):
+            with open("./OWNERS", "r") as owners_file:
+                owners = owners_file.readlines()
+                found = False
+            for owner in owners:
+                if owner.find(author) != -1:
+                found = True
+            if not ((author_association != "OWNER") or (author_association != "MEMBER") or (found == True)):
                 return_comment = f"Hi @{author},\n you are not authorised to run `/deploy` command.\n Please contact the OWNERS."
         if return_comment:
             post_comment(return_comment)

--- a/tasks/init-task.yaml
+++ b/tasks/init-task.yaml
@@ -82,12 +82,8 @@ spec:
         return_comment = ""
         if "/deploy" == received_comment:
             with open("./OWNERS", "r") as owners_file:
-                owners = owners_file.readlines()
-                found = False
-            for owner in owners:
-                if owner.find(author) != -1:
-                found = True
-            if not ((author_association != "OWNER") or (author_association != "MEMBER") or (found == True)):
+                owners = yaml.safe_load(owners_file)
+            if not (author_association == "OWNER" or author_association == "MEMBER" or author in owners["approvers"]):
                 return_comment = f"Hi @{author},\n you are not authorised to run `/deploy` command.\n Please contact the OWNERS."
         if return_comment:
             post_comment(return_comment)


### PR DESCRIPTION
## Related Issues and Dependencies

The issue is that permissions are only checked by a developer's access to GitHub organizations, but we want the ability to easily modify and add privileges to others to make changes.

Additionally, ran pre-commit and linted the sesheta request issue template so that the pre-commit check can pass.

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

After receiving the response on the PR, the task will now read the owners file and include that in its searching to see if a user has access to the repository.

## Description

issue itself still waiting to be created.
