### PR TITLE
Propogate requirements info to a specific dir

### DIFF
--- a/docs/gather-metrics-deployments-pipeline.md
+++ b/docs/gather-metrics-deployments-pipeline.md
@@ -32,14 +32,14 @@ The pipeline diagram and behaviour can be seen in the following image:
 
 The pipeline is triggered when a new Pull Request is opened on the users repo. To be more precise this particular pipeline is made of 1 + N pipelines, where N is the number of ML models to be deployed.
 
-The `main pipeline` will perform the following steps: 
+The `main pipeline` will perform the following steps:
 - check inputs from `.aicoe.yaml` to verify deployments exist;
-- configure all parameters for the following task; 
-- schedule `N pipelineruns`, where `N` is the number of deployments. 
+- configure all parameters for the following task;
+- schedule `N pipelineruns`, where `N` is the number of deployments.
 
 ![multiple deployments](./multiple-deployments.png)
 
-- watch the N pipelines monitoring status and wait until those will finish (Failed or Succeeded). 
+- watch the N pipelines monitoring status and wait until those will finish (Failed or Succeeded).
 - once the N pipelines finishes, the last task will collect the metrics gathered, post process them and comment on the Pull Request initially opened.
 
 Each of the `N pipelines` will perform the following steps:

--- a/tasks/issue-release-task.yaml
+++ b/tasks/issue-release-task.yaml
@@ -132,6 +132,18 @@ spec:
         git tag "${TAG//[[:space:]]/}"
         git checkout "${TAG//[[:space:]]/}" -b workbranch
 
+    - name: pre-package-extract
+      image: $(resources.inputs.s2i-thoth.url)
+      workingDir: /workspace/repo
+      script: |
+        mkdir /opt/aicoe-ci
+        if [ -f Pipfile ]; then
+          cp -r Pipfile /opt/aicoe-ci
+        fi
+        if [ -f Pipfile.lock ]; then
+          cp -r Pipfile.lock /opt/aicoe-ci
+        fi
+
     - name: generate
       image: quay.io/openshift-pipeline/s2i:nightly
       workingDir: /workspace/repo

--- a/tasks/overlay-build-task.yaml
+++ b/tasks/overlay-build-task.yaml
@@ -129,6 +129,13 @@ spec:
         rm -rf Pipfile Pipfile.lock
         if [ ! -z "$(params.overlays_dir)" ]; then
           cp -rf $(params.overlays_dir)/$(params.overlays_name)/* .
+          mkdir /opt/aicoe-ci
+          if [ -f Pipfile ]; then
+            cp -r Pipfile /opt/aicoe-ci
+          fi
+          if [ -f Pipfile.lock ]; then
+            cp -r Pipfile.lock /opt/aicoe-ci
+          fi
         fi
 
     - name: generate

--- a/tasks/pr-build-release.yaml
+++ b/tasks/pr-build-release.yaml
@@ -118,6 +118,18 @@ spec:
         git fetch origin pull/$(params.pr_number)/head:workbranch
         git checkout workbranch
 
+    - name: pre-package-extract
+      image: $(resources.inputs.s2i-thoth.url)
+      workingDir: /workspace/repo
+      script: |
+        mkdir /opt/aicoe-ci
+        if [ -f Pipfile ]; then
+          cp -r Pipfile /opt/aicoe-ci
+        fi
+        if [ -f Pipfile.lock ]; then
+          cp -r Pipfile.lock /opt/aicoe-ci
+        fi
+
     - name: generate
       image: quay.io/openshift-pipeline/s2i:nightly
       workingDir: /workspace/repo

--- a/tasks/tag-release-task.yaml
+++ b/tasks/tag-release-task.yaml
@@ -114,6 +114,18 @@ spec:
         git fetch origin --tags
         git checkout tags/$(params.git_ref) -b workbranch
 
+    - name: pre-package-extract
+      image: $(resources.inputs.s2i-thoth.url)
+      workingDir: /workspace/repo
+      script: |
+        mkdir /opt/aicoe-ci
+        if [ -f Pipfile ]; then
+          cp -r Pipfile /opt/aicoe-ci
+        fi
+        if [ -f Pipfile.lock ]; then
+          cp -r Pipfile.lock /opt/aicoe-ci
+        fi
+
     - name: generate
       image: quay.io/openshift-pipeline/s2i:nightly
       workingDir: /workspace/repo


### PR DESCRIPTION
Propogate requirements info to a specific dir
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/package-extract/pull/459

## Description

This would place the requirements into the /opt/aicoe-ci for package extraction.