### PR TITLE
Using the python -m build for generating package artifacts

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,13 @@
+presubmits:
+  - name: pre-commit
+    decorate: true
+    skip_report: false
+    always_run: true
+    context: aicoe-ci/prow/pre-commit
+    spec:
+      containers:
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.13.0
+          command:
+            - "pre-commit"
+            - "run"
+            - "--all-files"

--- a/tasks/issue-pypi-release-task.yaml
+++ b/tasks/issue-pypi-release-task.yaml
@@ -45,7 +45,6 @@ spec:
         TAG=$(echo "$(params.issue_body)" | awk -F ':' '{print $2}')
         set -x
         git fetch origin --tags
-        git tag "${TAG//[[:space:]]/}"
         git checkout "${TAG//[[:space:]]/}" -b workbranch
 
     - name: build-package
@@ -54,7 +53,7 @@ spec:
       securityContext:
         privileged: true
       script: |
-        python setup.py sdist bdist_wheel
+        python -m build --sdist --wheel
         python setup.py --name > package_name.txt
 
     - name: upload-package

--- a/tasks/upload-pypi.yaml
+++ b/tasks/upload-pypi.yaml
@@ -31,7 +31,7 @@ spec:
       securityContext:
         privileged: true
       script: |
-        python setup.py sdist bdist_wheel
+        python -m build --sdist --wheel
 
     - name: upload-package
       image: quay.io/thoth-station/twine:latest


### PR DESCRIPTION
Using the python -m build for generating package artifacts
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

Upgrading to the latest standards
https://packaging.python.org/en/latest/tutorials/packaging-projects/#generating-distribution-archives