### PR TITLE
Remove maintainer list from .thoth.yaml

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -2,9 +2,6 @@ managers:
   - name: info
   - name: version
     configuration:
-      maintainers:
-        - goern
-        - harshad16
       assignees:
         - sesheta
       labels: [bot]


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/AICoE/aicoe-ci/issues/165 was closed by khebhut saying I'm not a maintainer. But [I am](https://github.com/AICoE/aicoe-ci/blob/29e1e49cbfa9d98601fb0393194027f277d0879a/OWNERS#L4).

## This introduces a breaking change

No

## This Pull Request implements

This removes an explicit list of maintainers from `.thoth.yaml` so that it does not contradict `OWNERS`.

## Description

Kebechet will use the approvers in OWNERS instead
