### PR TITLE
:bug: fix a double quote problem, like: if ""paddock"" == overlay_name:

### DIFF
--- a/tasks/pr-config.yaml
+++ b/tasks/pr-config.yaml
@@ -112,7 +112,7 @@ spec:
         if conf.get("overlays"):
             for overlay in conf.get("overlays", []):
                 overlay_name = overlay.get("name")
-                if "$(params.overlay_name)" == overlay_name:
+                if $(params.overlay_name) == overlay_name:
                     for ele in overlay.get("build", []):
                         if isinstance(overlay["build"].get(ele), str):
                             if ele == "build-strategy":


### PR DESCRIPTION
Signed-off-by: Christoph Görn <goern@redhat.com>
